### PR TITLE
Quickstart hacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,12 @@
 .idea/
+.env
+env/
+venv/
+cache/
+__pycache__/
+*.pyc
+config.py
+error.log
+*.ipynb
+derby.log
+metastore_db/

--- a/check-docstyle.sh
+++ b/check-docstyle.sh
@@ -1,4 +1,4 @@
-directories="src test"
+directories="src tests"
 pass=0
 fail=0
 

--- a/src/recommender.py
+++ b/src/recommender.py
@@ -366,7 +366,7 @@ class RecommendationTask:
             _logger.error("%s" % e)
             return None
 
-    def execute(self, arguments=None, persist=True):
+    def execute(self, arguments=None, persist=True, check_license=False):
         started_at = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%f")
         results = arguments.get('result', None)
         external_request_id = arguments.get('external_request_id', None)
@@ -488,7 +488,7 @@ class RecommendationTask:
                     _logger.info("Alternate Packages Filtered for external_request_id {} {}"
                                  .format(external_request_id,
                                          filtered_alternate_packages))
-                    if persist:
+                    if check_license:
                         # apply license based filters
                         list_user_stack_comp = extract_user_stack_package_licenses(
                             resolved, ecosystem)

--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -27,7 +27,9 @@ def stack_recommender():
     if input_json and 'external_request_id' in input_json and input_json['external_request_id']:
         try:
             persist = request.args.get('persist', 'true') == 'true'
-            r = StackRecommender().execute(input_json, persist)
+            check_license = request.args.get(
+                'check_license', 'false') == 'true'
+            r = StackRecommender().execute(input_json, persist, check_license)
             status = 200
         except Exception as e:
             r = {

--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -27,9 +27,7 @@ def stack_recommender():
     if input_json and 'external_request_id' in input_json and input_json['external_request_id']:
         try:
             persist = request.args.get('persist', 'true') == 'true'
-            check_license = request.args.get(
-                'check_license', 'false') == 'true'
-            r = StackRecommender().execute(input_json, persist, check_license)
+            r = StackRecommender().execute(input_json, persist)
             status = 200
         except Exception as e:
             r = {
@@ -49,7 +47,8 @@ def recommender():
     input_json = request.get_json()
     if input_json and 'external_request_id' in input_json and input_json['external_request_id']:
         try:
-            r = RecommendationTask().execute(input_json)
+            check_license = request.args.get('check_license', 'false') == 'true'
+            r = RecommendationTask().execute(input_json, check_license=check_license)
             status = 200
         except Exception as e:
             r = {
@@ -68,7 +67,8 @@ def stack_aggregator():
     input_json = request.get_json()
     if input_json and 'external_request_id' in input_json and input_json['external_request_id']:
         try:
-            s = StackAggregator().execute(input_json)
+            check_license = request.args.get('check_license', 'false') == 'true'
+            s = StackAggregator().execute(input_json, check_license=check_license)
         except Exception as e:
             s = {
                 'stack_aggregator': 'unexpected error',

--- a/src/stack_recommender.py
+++ b/src/stack_recommender.py
@@ -8,6 +8,7 @@ from concurrent import futures
 
 
 class StackRecommender:
+
     def __init__(self):
         self.recommender_task = None
         self.stack_aggregator_task = None
@@ -16,19 +17,19 @@ class StackRecommender:
         asyncio.set_event_loop(self.loop)
 
     @asyncio.coroutine
-    def recommender_result(self, input_json, persist):
+    def recommender_result(self, input_json, persist, check_license):
         self.recommender_task = yield from self.loop.run_in_executor(
-            self.executor, RecommendationTask().execute, input_json, persist)
+            self.executor, RecommendationTask().execute, input_json, persist, check_license)
 
     @asyncio.coroutine
     def aggregator_result(self, input_json, persist):
         self.stack_aggregator_task = yield from self.loop.run_in_executor(
-            self.executor, StackAggregator().execute, input_json, persist)
+            self.executor, StackAggregator().execute, input_json, persist, check_license)
 
-    def execute(self, input_json, persist=True):
+    def execute(self, input_json, persist=True, check_license=False):
         try:
-            tasks = [self.recommender_result(input_json, persist),
-                     self.aggregator_result(input_json, persist)]
+            tasks = [self.recommender_result(input_json, persist, check_license),
+                     self.aggregator_result(input_json, persist, check_license)]
             self.loop.run_until_complete(asyncio.gather(*tasks))
             return {
                 'status': 'success',

--- a/src/stack_recommender.py
+++ b/src/stack_recommender.py
@@ -17,19 +17,19 @@ class StackRecommender:
         asyncio.set_event_loop(self.loop)
 
     @asyncio.coroutine
-    def recommender_result(self, input_json, persist, check_license):
+    def recommender_result(self, input_json, persist):
         self.recommender_task = yield from self.loop.run_in_executor(
-            self.executor, RecommendationTask().execute, input_json, persist, check_license)
+            self.executor, RecommendationTask().execute, input_json, persist)
 
     @asyncio.coroutine
     def aggregator_result(self, input_json, persist):
         self.stack_aggregator_task = yield from self.loop.run_in_executor(
-            self.executor, StackAggregator().execute, input_json, persist, check_license)
+            self.executor, StackAggregator().execute, input_json, persist)
 
-    def execute(self, input_json, persist=True, check_license=False):
+    def execute(self, input_json, persist=True):
         try:
-            tasks = [self.recommender_result(input_json, persist, check_license),
-                     self.aggregator_result(input_json, persist, check_license)]
+            tasks = [self.recommender_result(input_json, persist),
+                     self.aggregator_result(input_json, persist)]
             self.loop.run_until_complete(asyncio.gather(*tasks))
             return {
                 'status': 'success',


### PR DESCRIPTION
Make use of `check_license` flag. The `persist` flag was earlier being used to filter license, and persist data in RDS. Now it is only used in persistence of data, as a new flag takes care of the filtering. For the time being, the default is set to `false`, as we want to bypass the license and unknown dependency logic.