### PR TITLE
Fix unknown_dependency len w.r.t using check_license filter

### DIFF
--- a/src/stack_aggregator.py
+++ b/src/stack_aggregator.py
@@ -334,8 +334,8 @@ def aggregate_stack_data(stack, manifest_file, ecosystem, deps, manifest_file_pa
                 "ecosystem": ecosystem,
                 "analyzed_dependencies_count": len(dependencies),
                 "analyzed_dependencies": dependencies,
-                "unknown_dependencies_count": len(deps) - len(dependencies),
                 "unknown_dependencies": unknown_dependencies,
+                "unknown_dependencies_count": len(unknown_dependencies),
                 "recommendation_ready": True,  # based on the percentage of dependencies analysed
                 "total_licenses": len(stack_distinct_licenses),
                 "distinct_licenses": list(stack_distinct_licenses),


### PR DESCRIPTION
Fix this issue when `unknown_dep len=[]`, but count is not zero.
![screenshot from 2018-03-08 13-17-38](https://user-images.githubusercontent.com/7047079/37142133-2d627516-22dd-11e8-923b-dbfff3b50ea3.png)
