### PR TITLE
Fix use of str instead of int in semantic versioning

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -148,12 +148,16 @@ def create_package_dict(graph_results, alt_dict=None):
 
 
 def convert_version_to_proper_semantic(version):
-    """needed for maven version like 1.5.2.RELEASE to be converted to
+    """Perform Semantic versioning.
+    :param version: The raw input version that needs to be converted.
+    :return: The semantic version of raw input version.
+
+    Needed for maven version like 1.5.2.RELEASE to be converted to
     1.5.2-RELEASE for semantic version to work'"""
+    if version in ('', '-1', None):
+        return '0.0.0'
     version = version.replace('.', '-', 3)
     version = version.replace('-', '.', 2)
-    if version in ('', -1, None):
-        return '0.0.0'
     return version
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,14 @@
+from src.utils import convert_version_to_proper_semantic as cvs
+
+
+def test_semantic_versionin():
+    version = "-1"
+    assert cvs(version) == "0.0.0"
+    version = ""
+    assert cvs(version) == "0.0.0"
+    version = None
+    assert cvs(version) == "0.0.0"
+    version = "1.5.2.RELEASE"
+    assert cvs(version) == "1.5.2-RELEASE"
+    version = "1.5-2.RELEASE"
+    assert cvs(version) == "1.5.2-RELEASE"


### PR DESCRIPTION
As per the discussion https://github.com/fabric8-analytics/f8a-server-backbone/pull/34#discussion-diff-175004334R164