### PR TITLE
Add call to the NPM insights service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       LICENSE_SERVICE_HOST: "f8a-license-analysis"
       LICENSE_SERVICE_PORT: "6162"
       PGM_SERVICE_HOST: "bayesian-kronos"
+      CHESTER_SERVICE_HOST: "f8a-chester"
       PGM_SERVICE_PORT : "6006"
       POSTGRESQL_USER: "user"
       POSTGRESQL_PASSWORD: "password"

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -40,6 +40,8 @@ objects:
             value: "6162"
           - name: PGM_SERVICE_HOST
             value: bayesian-kronos
+          - name: CHESTER_SERVICE_HOST
+            value: f8a-chester
           - name: PGM_SERVICE_PORT
             value: "6006"
           - name: POSTGRESQL_DATABASE

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash -ex
+#!/bin/bash -ex
 
 gc() {
   retval=$?
@@ -28,7 +28,7 @@ function prepare_venv() {
         VIRTUALENV=`which virtualenv-3`
     fi
 
-    ${VIRTUALENV} -p python3 venv && source venv/bin/activate 
+    ${VIRTUALENV} -p python3 venv && source venv/bin/activate
     pip install -U pip
     python3 `which pip3` install -r requirements.txt
 
@@ -40,4 +40,4 @@ function prepare_venv() {
 `which pip3` install pytest
 `which pip3` install pytest-cov
 
-PYTHONDONTWRITEBYTECODE=1 python3 `which pytest` --cov=src/ --cov-report term-missing -vv tests/
+PYTHONDONTWRITEBYTECODE=1 CHESTER_SERVICE_HOST='chester' PGM_SERVICE_HOST='pgm' PGM_SERVICE_PORT='6006' python3 `which pytest` --cov=src/ --cov-report term-missing -vv tests/

--- a/tests/test_recommender.py
+++ b/tests/test_recommender.py
@@ -1,4 +1,46 @@
 """Tests for the recommender module."""
+from unittest import TestCase
+from unittest import mock
+import logging
+logger = logging.getLogger(__name__)
 
-if __name__ == '__main__':
-    pass
+from recommender import RecommendationTask
+from rest_api import app
+
+
+def mocked_requests_get(*args, **kwargs):
+    """Mock the call to the insights service."""
+    class MockResponse:
+        """Mock response object."""
+
+        def __init__(self, json_data, status_code):
+            """Create a mock json response."""
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def json(self):
+            """Get the mock json response."""
+            return self.json_data
+
+    # return the URL to check whether we are calling the correct service.
+    return MockResponse({"url": args[0]}, 200)
+
+
+class TestRecommendationTask(TestCase):
+    """Tests for the recommendation task class."""
+
+    @mock.patch('requests.get', side_effect=mocked_requests_get)
+    @mock.patch('requests.Session.post', side_effect=mocked_requests_get)
+    def test_call_insights_recommender_npm(self, mock_get, mock_post):
+        """Test if the correct service is called for the correct ecosystem."""
+        with app.app_context():
+            # Test whether the correct service is called for NPM.
+            called_url_json = RecommendationTask.call_insights_recommender([{
+                "ecosystem": "npm"
+            }])
+            self.assertTrue('chester' in called_url_json['url'])
+            # Now test whether the correct service is called for maven.
+            called_url_json = RecommendationTask.call_insights_recommender([{
+                "ecosystem": "maven"
+            }])
+            self.assertTrue('pgm' in called_url_json['url'])


### PR DESCRIPTION
This PR contains:

* Logic to call the NPM insights service
* Unit test to check that the correct recommender is called
* Changes to template and docker-compose for new service
* empty key handling in various places as the new service does not recommend companions or give outliers
* A fix for the `runtest.sh` script on Mac (there is no `/usr/bin/bash` on mac, however there is a `/bin/bash`) on everything.

Signed-off-by: Avishkar Gupta <avgupta@redhat.com>