### PR TITLE
Introduce RHEL based image

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,28 @@
+# base image source https://github.com/rhdt/EL-Dockerfiles/blob/master/base/python3/Dockerfile
+
+FROM prod.registry.devshift.net/osio-prod/base/python3:latest
+
+ENV F8A_WORKER_VERSION=c019a1e
+LABEL name="f8analytics backbone services" \
+      description="Stack aggregation and recommendation service." \
+      git-sha="46e443d" \
+      email-ids="nshaikh@redhat.com,samuzzal@redhat.com" \
+      git-url="https://github.com/fabric8-analytics/f8a-server-backbone" \
+      git-path="/" \
+      target-file="Dockerfile" \
+      app-license="GPL-3.0"
+
+COPY ./requirements.txt /
+
+RUN pip3 install --upgrade pip
+RUN pip3 install -r requirements.txt && rm requirements.txt
+
+COPY ./src /src
+
+RUN pip3 install git+https://github.com/fabric8-analytics/fabric8-analytics-worker.git@${F8A_WORKER_VERSION}
+
+ADD scripts/entrypoint.sh /bin/entrypoint.sh
+
+RUN chmod 777 /bin/entrypoint.sh
+
+ENTRYPOINT ["/bin/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ifeq ($(TARGET),rhel)
   REGISTRY := push.registry.devshift.net/osio-prod
 else
   DOCKERFILE := Dockerfile
-  REGISTRY := registry.devshift.net
+  REGISTRY := push.registry.devshift.net
 endif
 REPOSITORY?=fabric8-analytics/f8a-server-backbone
 DEFAULT_TAG=latest

--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,8 @@ test:
 get-image-name:
 	@echo $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG)
 
+get-image-repository:
+	@echo $(REPOSITORY)
+
 get-push-registry:
 	@echo $(REGISTRY)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-REGISTRY?=registry.devshift.net
+ifeq ($(TARGET),rhel)
+  DOCKERFILE := Dockerfile.rhel
+  REGISTRY := push.registry.devshift.net/osio-prod
+else
+  DOCKERFILE := Dockerfile
+  REGISTRY := registry.devshift.net
+endif
 REPOSITORY?=fabric8-analytics/f8a-server-backbone
 DEFAULT_TAG=latest
 
@@ -7,10 +13,10 @@ DEFAULT_TAG=latest
 all: fast-docker-build
 
 docker-build:
-	docker build --no-cache -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f Dockerfile .
+	docker build --no-cache -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f $(DOCKERFILE) .
 
 fast-docker-build:
-	docker build -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f Dockerfile .
+	docker build -t $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG) -f $(DOCKERFILE) .
 
 test:
 	./runtests.sh
@@ -18,6 +24,5 @@ test:
 get-image-name:
 	@echo $(REGISTRY)/$(REPOSITORY):$(DEFAULT_TAG)
 
-get-image-repository:
-	@echo $(REPOSITORY)
-
+get-push-registry:
+	@echo $(REGISTRY)

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -20,6 +20,15 @@ prep() {
 }
 
 build_image() {
+    local push_registry
+    push_registry=$(make get-push-registry)
+    # login before build to be able to pull RHEL parent image
+    if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
+        docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${push_registry}
+    else
+        echo "Could not login, missing credentials for the registry"
+        exit 1
+    fi
     make docker-build
 }
 
@@ -38,15 +47,7 @@ push_image() {
     image_name=$(make get-image-name)
     image_repository=$(make get-image-repository)
     short_commit=$(git rev-parse --short=7 HEAD)
-    push_registry="push.registry.devshift.net"
-
-    # login first
-    if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-        docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${push_registry}
-    else
-        echo "Could not login, missing credentials for the registry"
-        exit 1
-    fi
+    push_registry=$(make get-push-registry)
 
     if [ -n "${ghprbPullId}" ]; then
         # PR build


### PR DESCRIPTION
Enable build on RHEL if TARGET=rhel.

The cico environment will continue to build the CentOS based container and in a second step it will build and push a RHEL based container.

depends on:
- https://github.com/rhdt/EL-Dockerfiles/pull/39
- https://github.com/openshiftio/openshiftio-cico-jobs/pull/629

cc: @jmelis @msrb @tisnik 