### PR TITLE
[openshift] Lower initialDelaySeconds for readiness probe from 60 to 20 seconds

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -86,7 +86,7 @@ objects:
               port: ${{API_BACKBONE_SERVICE_PORT}}
             failureThreshold: 3
             successThreshold: 1
-            initialDelaySeconds: 60
+            initialDelaySeconds: 20
             periodSeconds: 60
             timeoutSeconds: 30
           resources:


### PR DESCRIPTION
No need to wait that long for service to be considered ready.