### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,6 +1,6 @@
 # base image source https://github.com/rhdt/EL-Dockerfiles/blob/master/base/python3/Dockerfile
 
-FROM prod.registry.devshift.net/osio-prod/base/python3:latest
+FROM quay.io/openshiftio/rhel-base-python3:latest
 
 ENV F8A_WORKER_VERSION=c019a1e
 LABEL name="f8analytics backbone services" \

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 ifeq ($(TARGET),rhel)
   DOCKERFILE := Dockerfile.rhel
-  REGISTRY := push.registry.devshift.net/osio-prod
+  REGISTRY := quay.io
+  REPOSITORY := openshiftio/rhel-fabric8-analytics-f8a-server-backbone
 else
   DOCKERFILE := Dockerfile
-  REGISTRY := push.registry.devshift.net
+  REGISTRY := quay.io
+  REPOSITORY := openshiftio/fabric8-analytics-f8a-server-backbone
 endif
-REPOSITORY?=fabric8-analytics/f8a-server-backbone
+
 DEFAULT_TAG=latest
 
 .PHONY: all docker-build fast-docker-build test get-image-name get-image-repository

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -1,12 +1,19 @@
 #!/bin/bash -ex
 
 load_jenkins_vars() {
-    if [ -e "jenkins-env" ]; then
-        <jenkins-env \
-          grep -E "(DEVSHIFT_TAG_LEN|DEVSHIFT_USERNAME|DEVSHIFT_PASSWORD|JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId)=" \
-          | sed 's/^/export /g' \
-          > ~/.jenkins-env
-        source ~/.jenkins-env
+    if [ -e "jenkins-env.json" ]; then
+        eval "$(./env-toolkit load -f jenkins-env.json \
+                DEVSHIFT_TAG_LEN \
+                QUAY_USERNAME \
+                QUAY_PASSWORD \
+                JENKINS_URL \
+                GIT_BRANCH \
+                GIT_COMMIT \
+                BUILD_NUMBER \
+                ghprbSourceBranch \
+                ghprbActualCommit \
+                BUILD_URL \
+                ghprbPullId)"
     fi
 }
 
@@ -24,8 +31,8 @@ build_image() {
     local push_registry
     push_registry=$(make get-push-registry)
     # login before build to be able to pull RHEL parent image
-    if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-        docker login -u "${DEVSHIFT_USERNAME}" -p "${DEVSHIFT_PASSWORD}" "${push_registry}"
+    if [ -n "${QUAY_USERNAME}" -a -n "${QUAY_PASSWORD}" ]; then
+        docker login -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" "${push_registry}"
     else
         echo "Could not login, missing credentials for the registry"
         exit 1
@@ -43,11 +50,12 @@ tag_push() {
 push_image() {
     local image_name
     local image_repository
-    local short_commit 
+    local short_commit
     local push_registry
+
     image_name=$(make get-image-name)
     image_repository=$(make get-image-repository)
-    short_commit=$(git rev-parse --short=7 HEAD)
+    short_commit=$(git rev-parse --short=$DEVSHIFT_TAG_LEN HEAD)
     push_registry=$(make get-push-registry)
 
     if [ -n "${ghprbPullId}" ]; then


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo to change the staging url from devshift to quay. The PR to the saas repo should be merged before this one.
https://github.com/openshiftio/saas-analytics/pull/404