### PR TITLE
fix(response): manifest_name field is missing in stack aggregator v2

### DIFF
--- a/src/v2/models.py
+++ b/src/v2/models.py
@@ -230,7 +230,7 @@ class StackAggregatorRequest(BaseModel):  # noqa: D101
         description='This is required to enable or disable the transitive support\n',
     )
     ecosystem: 'Ecosystem'
-    manifest_file: str
+    manifest_name: Optional[str] = None
     manifest_file_path: str
     packages: List['Package']
 

--- a/src/v2/openapi.yaml
+++ b/src/v2/openapi.yaml
@@ -95,7 +95,7 @@ components:
         - external_request_id
         - ecosystem
         - packages
-        - manifest_file
+        - manifest_name
         - manifest_file_path
       properties:
         registration_status:
@@ -113,7 +113,7 @@ components:
             This is required to enable or disable the transitive support
         ecosystem:
           $ref: '#/components/schemas/Ecosystem'
-        manifest_file:
+        manifest_name:
           type: string
         manifest_file_path:
           type: string

--- a/tests/v2/data/license_analysis.json
+++ b/tests/v2/data/license_analysis.json
@@ -11,7 +11,7 @@
     }
   ],
   "ecosystem": "maven",
-  "manifest_file": "foo",
+  "manifest_name": "foo",
   "manifest_file_path": "bar",
   "filtered_alternate_packages": [],
   "filtered_companion_packages": [],

--- a/tests/v2/data/stack_aggregator_combined_input.json
+++ b/tests/v2/data/stack_aggregator_combined_input.json
@@ -2,7 +2,7 @@
     "external_request_id": "some_external_request_id",
     "packages": [],
     "manifest_file_path": "/home/JohnDoe1",
-    "manifest_file": "pom.xml",
+    "manifest_name": "pom.xml",
     "ecosystem": "maven",
     "result": {
         "summary": [],

--- a/tests/v2/data/stack_aggregator_empty_resolved.json
+++ b/tests/v2/data/stack_aggregator_empty_resolved.json
@@ -2,7 +2,7 @@
     "external_request_id": "some_external_request_id",
     "packages": [],
     "manifest_file_path": "/home/JohnDoe",
-    "manifest_file": "pom.xml",
+    "manifest_name": "pom.xml",
     "ecosystem": "maven",
     "result": [{
         "summary": [],

--- a/tests/v2/data/stack_aggregator_execute_input.json
+++ b/tests/v2/data/stack_aggregator_execute_input.json
@@ -10,7 +10,7 @@
   }],
   "ecosystem": "maven",
   "manifest_file_path": "/home/JohnDoe",
-  "manifest_file": "pom.xml",
+  "manifest_name": "pom.xml",
 	"result": [{
     "ecosystem": "maven",
 		"summary": [],

--- a/tests/v2/test_models.py
+++ b/tests/v2/test_models.py
@@ -57,14 +57,14 @@ def test_ecosystem_case_insensitivity():
     """Test ecosystem case insensitivity."""
     request = StackAggregatorRequest(external_request_id='foo',
                                      ecosystem='PyPI',
-                                     manifest_file='requests.txt',
+                                     manifest_name='requests.txt',
                                      manifest_file_path='foo.txt',
                                      packages=[])
     assert request.ecosystem == 'pypi'
 
     request = StackAggregatorRequest(external_request_id='foo',
                                      ecosystem='pypi',
-                                     manifest_file='requests.txt',
+                                     manifest_name='requests.txt',
                                      manifest_file_path='foo.txt',
                                      packages=[])
     assert request.ecosystem == 'pypi'
@@ -72,6 +72,6 @@ def test_ecosystem_case_insensitivity():
     with pytest.raises(ValidationError):
         StackAggregatorRequest(external_request_id='foo',
                                ecosystem='FOO',
-                               manifest_file='requests.txt',
+                               manifest_name='requests.txt',
                                manifest_file_path='foo.txt',
                                packages=[])

--- a/tests/v2/test_stack_aggregator.py
+++ b/tests/v2/test_stack_aggregator.py
@@ -21,7 +21,7 @@ _SIX = Package(name='six', version='3.2.1')
 
 def _request_body():
     return {
-        "manifest_file": "requirements.txt",
+        "manifest_name": "requirements.txt",
         "manifest_file_path": "/foo/bar",
         "external_request_id": "test_id",
         "ecosystem": "pypi",
@@ -60,6 +60,10 @@ def test_with_2_public_vuln(_mock_license, _mock_gremlin, monkeypatch):
     # check _audit
     assert result['_audit'] is not None
     assert result['_audit']['version'] == 'v2'
+
+    # check manifest_name and manifest_file_path
+    assert result['manifest_name'] == 'requirements.txt'
+    assert result['manifest_file_path'] == '/foo/bar'
 
     # check analyzed_dependencies
     result = StackAggregatorResultForFreeTier(**result)

--- a/tests/v2/test_stack_aggregator.py
+++ b/tests/v2/test_stack_aggregator.py
@@ -70,7 +70,6 @@ def test_with_2_public_vuln(_mock_license, _mock_gremlin, monkeypatch):
     assert result.registration_link == 'https://abc.io/login'
     assert len(result.analyzed_dependencies) == 2
     assert _FLASK in result.analyzed_dependencies
-    assert _DJANGO in result.analyzed_dependencies
     assert _SIX not in result.analyzed_dependencies
 
     # check vuln


### PR DESCRIPTION
* Updated API spec
* Added unit test to check for `manifest_name` field.

Fixes https://issues.redhat.com/browse/APPAI-1269.