### PR TITLE
fix(recommender): Add missing fields cooccurrence_probability and cooccurrence_count

### DIFF
--- a/src/v2/models.py
+++ b/src/v2/models.py
@@ -173,8 +173,8 @@ class PackageDetailsForFreeTier(PackageDetails):  # noqa: D101
 
 
 class RecommendedPackageData(PackageDetails):  # noqa: D101
-    confidence_reason: Optional[float] = None
-    reason: Optional[str] = None
+    cooccurrence_probability: Optional[float] = 0
+    cooccurrence_count: int = 0
     topic_list: Optional[List[str]] = None
 
 

--- a/src/v2/models.py
+++ b/src/v2/models.py
@@ -240,13 +240,14 @@ class StackAggregatorRequest(BaseModel):  # noqa: D101
 
 
 class StackRecommendationResult(BaseModel):  # noqa: D101
-    _audit: 'Audit'
-    uuid: UUID
+    _audit: 'Audit' = None
+    uuid: UUID = None
     external_request_id: str
+    manifest_file_path: str = None
+    manifest_name: str = None
     registration_status: 'RegistrationStatus'
-    recommendation_status: 'RecommendationStatus'
+    recommendation_status: 'RecommendationStatus' = 'success'
     companion: List['RecommendedPackageData']
-    manifest_file_path: str
     usage_outliers: List[Dict[str, Any]]
 
 
@@ -257,3 +258,4 @@ class RecommenderRequest(StackAggregatorRequest):  # noqa: D101
 Package.update_forward_refs()
 PackageDetailsForRegisteredUser.update_forward_refs()
 PackageDetailsForFreeTier.update_forward_refs()
+RecommendedPackageData.update_forward_refs()

--- a/src/v2/openapi.yaml
+++ b/src/v2/openapi.yaml
@@ -493,11 +493,11 @@ components:
       - $ref: '#/components/schemas/PackageDetails'
       - type: object
         properties:
-          confidence_reason:
+          cooccurrence_probability:
             type: number
             format: float
             example: 83.16431
-          reason:
+          cooccurrence_count:
             type: string
           topic_list:
             type: array
@@ -540,7 +540,7 @@ components:
           enum:
             - success
             - pgm_error
-          example: success
+          default: success
         companion:
           type: array
           items:

--- a/src/v2/recommender.py
+++ b/src/v2/recommender.py
@@ -169,7 +169,7 @@ class GraphDB:
             if name:
                 for pgm_epv in pgm_list:
                     if name == pgm_epv.get('package_name', ''):
-                        epv['package']['pgm_topics'] = pgm_epv.get('topic_list', [])
+                        epv['package']['topic_list'] = pgm_epv.get('topic_list', [])
                         epv['package']['cooccurrence_probability'] = pgm_epv.get(
                             'cooccurrence_probability', 0)
                         epv['package']['cooccurrence_count'] = pgm_epv.get(

--- a/src/v2/recommender.py
+++ b/src/v2/recommender.py
@@ -15,7 +15,7 @@ from src.utils import (create_package_dict, get_session_retry, select_latest_ver
                        LICENSE_SCORING_URL_REST, convert_version_to_proper_semantic,
                        get_response_data, version_info_tuple, persist_data_in_db,
                        is_quickstart_majority, post_gremlin)
-from src.v2.models import RecommenderRequest
+from src.v2.models import RecommenderRequest, StackRecommendationResult
 from src.v2.stack_aggregator import extract_user_stack_package_licenses
 from src.v2.normalized_packages import NormalizedPackages
 
@@ -361,7 +361,6 @@ class RecommendationTask:
         recommendation = {
             'companion': [],
             'usage_outliers': [],
-            'manifest_file_path': request.manifest_file_path
         }
         package_list = [epv.name for epv in normalized_packages.direct_dependencies]
         if package_list:
@@ -462,6 +461,8 @@ class RecommendationTask:
         ended_at = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%f")
         audit = {'started_at': started_at, 'ended_at': ended_at, 'version': 'v2'}
 
+        recommendation = StackRecommendationResult(**recommendation,
+                                                   **request.dict()).dict()
         recommendation['_audit'] = audit
 
         if persist:


### PR DESCRIPTION
* Add missing fields cooccurrence_probability and cooccurrence_count.
* Currently v2 recommender doesn't use any response model because it is still heavily based on v1. However the defined model could be used to validate the response.