### PR TITLE
fix: Don't include unknown transitive as part of unknown_dependencies

### DIFF
--- a/src/v2/stack_aggregator.py
+++ b/src/v2/stack_aggregator.py
@@ -404,7 +404,7 @@ def initiate_unknown_package_ingestion(aggregator: Aggregator):
             server_create_analysis(ecosystem, dep.name, dep.version, api_flow=True,
                                    force=False, force_graph_sync=True)
     except Exception as e:  # pylint:disable=W0703,C0103
-        logger.error('Ingestion has been failed for {%s, %s, %s}',
+        logger.error('Ingestion failed for {%s, %s, %s}',
                      ecosystem, dep.name, dep.version)
         logger.error(e)
 

--- a/src/v2/stack_aggregator.py
+++ b/src/v2/stack_aggregator.py
@@ -323,7 +323,7 @@ class Aggregator(ABC):
                 server_create_analysis(ecosystem, dep.name, dep.version, api_flow=True,
                                        force=False, force_graph_sync=True)
         except Exception as e:  # pylint:disable=W0703,C0103
-            logger.error('Ingestion has been failed for {%s, %s, %s}',
+            logger.error('Ingestion failed for {%s, %s, %s}',
                          ecosystem, dep.name, dep.version)
             logger.error(e)
 


### PR DESCRIPTION
Transitives which are unknown to the platform shouldn't be included in the unknown deps list. However it should be silently trigger the ingestion.

Fixes: https://issues.redhat.com/browse/APPAI-1287