### PR TITLE
fix(license): Skip transitive licenses for analysis

### DIFF
--- a/src/v2/stack_aggregator.py
+++ b/src/v2/stack_aggregator.py
@@ -356,7 +356,7 @@ class Aggregator(ABC):
         # denormalize package details according to request.dependencies relations
         package_details = self._get_denormalized_package_details()
         unknown_dependencies = self._get_unknown_packages()
-        license_analysis = get_license_analysis_for_stack(self._normalized_package_details)
+        license_analysis = get_license_analysis_for_stack(package_details)
         return self.create_result(**self._request.dict(exclude={'packages'}),
                                   analyzed_dependencies=package_details,
                                   unknown_dependencies=unknown_dependencies,

--- a/tests/v2/test_license_service.py
+++ b/tests/v2/test_license_service.py
@@ -25,7 +25,7 @@ def _get_normalized_packages():
                                             ecosystem='pypi',
                                             licenses=['XYZ', 'ABC'])
 
-    return {flask: flask_details, six: six_details}
+    return [flask_details, six_details]
 
 
 def test_get_license_service_request_payload_args():


### PR DESCRIPTION
V2 implementation of stack aggregator considers transitive license details for analysis. It seems to be recommending Unknown license most of the time. As of now just skip license analysis for transitive packages.

Fixes: https://issues.redhat.com/browse/APPAI-1292