### PR TITLE
[APPAI-1294] Add environment variable to control the flow for unknown dependencies for stack analyses

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -101,6 +101,8 @@ objects:
             value: "metrics-accumulator"
           - name: METRICS_ENDPOINT_URL_PORT
             value: "5200"
+          - name: DISABLE_UNKNOWN_PACKAGE_FLOW
+            value: ${DISABLE_UNKNOWN_PACKAGE_FLOW}
 
           image: "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${IMAGE_TAG}"
           name: f8a-server-backbone
@@ -226,4 +228,10 @@ parameters:
   required: false
   name: FLASK_LOGGING_LEVEL
   value: "INFO"
+
+- description: Flag to enable or disable the unknown package ingetion flow
+  displayName: DISABLE UNKNOWN PACKAGE FLOW
+  required: false
+  name: DISABLE_UNKNOWN_PACKAGE_FLOW
+  value: "0"
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,6 +1,6 @@
 """Abstracts settings based on env variables."""
 
-import os
+
 from typing import Dict
 from pydantic import BaseSettings, HttpUrl
 
@@ -12,5 +12,4 @@ class Settings(BaseSettings):
     snyk_package_url_format: HttpUrl = 'https://snyk.io/vuln/{ecosystem}:{package}'
     snyk_signin_url: HttpUrl = 'https://snyk.io/login'
     snyk_ecosystem_map: Dict[str, str] = {"pypi": "pip"}
-
-    disable_unknown_package_flow: bool = os.environ.get("DISABLE_UNKNOWN_PACKAGE_FLOW", "") == "1"
+    disable_unknown_package_flow: bool = False

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,5 +1,6 @@
 """Abstracts settings based on env variables."""
 
+import os
 from typing import Dict
 from pydantic import BaseSettings, HttpUrl
 
@@ -11,3 +12,5 @@ class Settings(BaseSettings):
     snyk_package_url_format: HttpUrl = 'https://snyk.io/vuln/{ecosystem}:{package}'
     snyk_signin_url: HttpUrl = 'https://snyk.io/login'
     snyk_ecosystem_map: Dict[str, str] = {"pypi": "pip"}
+
+    disable_unknown_package_flow: bool = os.environ.get("DISABLE_UNKNOWN_PACKAGE_FLOW", "") == "1"

--- a/src/stack_aggregator.py
+++ b/src/stack_aggregator.py
@@ -663,18 +663,16 @@ class StackAggregator:
                          'result': stack_data}
         # Ingestion of Unknown dependencies
         logger.info("Unknown ingestion flow process initiated.")
-        try:
-            for dep in unknown_dep_list:
-                if Settings().disable_unknown_package_flow:
-                    logger.warning('Unknown package {} with version {} skipped as '
-                                   'DISABLE_UNKNOWN_PACKAGE_FLOW is set'.format(dep['name'],
-                                                                                dep['version']))
-                else:
+        if Settings().disable_unknown_package_flow:
+            logger.warning('Skipping unknown flow %s', unknown_dep_list)
+        else:
+            try:
+                for dep in unknown_dep_list:
                     server_create_analysis(ecosystem, dep['name'], dep['version'], api_flow=True,
                                            force=False, force_graph_sync=True)
-        except Exception as e:
-            logger.error('Ingestion has been failed for ' + dep['name'])
-            logger.error(e)
-            pass
+            except Exception as e:
+                logger.error('Ingestion has been failed for ' + dep['name'])
+                logger.error(e)
+                pass
 
         return persiststatus

--- a/src/stack_aggregator.py
+++ b/src/stack_aggregator.py
@@ -662,16 +662,19 @@ class StackAggregator:
                          'external_request_id': external_request_id,
                          'result': stack_data}
         # Ingestion of Unknown dependencies
-        if Settings().disable_unknown_package_flow:
-            logger.warning('Unknown package flow is disabled')
-        else:
-            logger.info("Unknown ingestion flow process initiated.")
-            try:
-                for dep in unknown_dep_list:
+        logger.info("Unknown ingestion flow process initiated.")
+        try:
+            for dep in unknown_dep_list:
+                if Settings().disable_unknown_package_flow:
+                    logger.warning('Unknown package {} with version {} skipped as '
+                                   'DISABLE_UNKNOWN_PACKAGE_FLOW is set'.format(dep['name'],
+                                                                                dep['version']))
+                else:
                     server_create_analysis(ecosystem, dep['name'], dep['version'], api_flow=True,
                                            force=False, force_graph_sync=True)
-            except Exception as e:
-                logger.error('Ingestion has been failed for ' + dep['name'])
-                logger.error(e)
-                pass
+        except Exception as e:
+            logger.error('Ingestion has been failed for ' + dep['name'])
+            logger.error(e)
+            pass
+
         return persiststatus

--- a/src/stack_aggregator.py
+++ b/src/stack_aggregator.py
@@ -12,6 +12,7 @@ from flask import current_app
 import requests
 import copy
 from collections import defaultdict
+from src.settings import Settings
 from src.utils import (select_latest_version, server_create_analysis, LICENSE_SCORING_URL_REST,
                        post_http_request, GREMLIN_SERVER_URL_REST, persist_data_in_db,
                        GREMLIN_QUERY_SIZE, format_date)
@@ -661,13 +662,16 @@ class StackAggregator:
                          'external_request_id': external_request_id,
                          'result': stack_data}
         # Ingestion of Unknown dependencies
-        logger.info("Unknown ingestion flow process initiated.")
-        try:
-            for dep in unknown_dep_list:
-                server_create_analysis(ecosystem, dep['name'], dep['version'], api_flow=True,
-                                       force=False, force_graph_sync=True)
-        except Exception as e:
-            logger.error('Ingestion has been failed for ' + dep['name'])
-            logger.error(e)
-            pass
+        if Settings().disable_unknown_package_flow:
+            logger.warning('Unknown package flow is disabled')
+        else:
+            logger.info("Unknown ingestion flow process initiated.")
+            try:
+                for dep in unknown_dep_list:
+                    server_create_analysis(ecosystem, dep['name'], dep['version'], api_flow=True,
+                                           force=False, force_graph_sync=True)
+            except Exception as e:
+                logger.error('Ingestion has been failed for ' + dep['name'])
+                logger.error(e)
+                pass
         return persiststatus

--- a/src/v2/stack_aggregator.py
+++ b/src/v2/stack_aggregator.py
@@ -401,7 +401,6 @@ def initiate_unknown_package_ingestion(aggregator: Aggregator):
     """Ingestion of Unknown dependencies."""
     if os.environ.get("DISABLE_UNKNOWN_PACKAGE_FLOW", "") == "1":
         logger.warning('Unknown package flow is disabled')
-        print('Unknown package flow is disabled')
     else:
         ecosystem = aggregator._normalized_packages.ecosystem
         try:

--- a/src/v2/stack_aggregator.py
+++ b/src/v2/stack_aggregator.py
@@ -4,6 +4,7 @@ Gathers component data from the graph database and aggregate the data to be pres
 by stack-analyses endpoint
 """
 
+import os
 import datetime
 import inspect
 import time
@@ -398,15 +399,16 @@ class Registered(Aggregator):
 
 def initiate_unknown_package_ingestion(aggregator: Aggregator):
     """Ingestion of Unknown dependencies."""
-    ecosystem = aggregator._normalized_packages.ecosystem
-    try:
-        for dep in aggregator.get_all_unknown_packages():
-            server_create_analysis(ecosystem, dep.name, dep.version, api_flow=True,
-                                   force=False, force_graph_sync=True)
-    except Exception as e:  # pylint:disable=W0703,C0103
-        logger.error('Ingestion failed for {%s, %s, %s}',
-                     ecosystem, dep.name, dep.version)
-        logger.error(e)
+    if os.environ.get("DISABLE_UNKNOWN_PACKAGE_FLOW", "") != "1":
+        ecosystem = aggregator._normalized_packages.ecosystem
+        try:
+            for dep in aggregator.get_all_unknown_packages():
+                server_create_analysis(ecosystem, dep.name, dep.version, api_flow=True,
+                                       force=False, force_graph_sync=True)
+        except Exception as e:  # pylint:disable=W0703,C0103
+            logger.error('Ingestion failed for {%s, %s, %s}',
+                         ecosystem, dep.name, dep.version)
+            logger.error(e)
 
 
 class StackAggregator:

--- a/src/v2/stack_aggregator.py
+++ b/src/v2/stack_aggregator.py
@@ -4,7 +4,6 @@ Gathers component data from the graph database and aggregate the data to be pres
 by stack-analyses endpoint
 """
 
-import os
 import datetime
 import inspect
 import time
@@ -399,7 +398,7 @@ class Registered(Aggregator):
 
 def initiate_unknown_package_ingestion(aggregator: Aggregator):
     """Ingestion of Unknown dependencies."""
-    if os.environ.get("DISABLE_UNKNOWN_PACKAGE_FLOW", "") == "1":
+    if Settings().disable_unknown_package_flow:
         logger.warning('Unknown package flow is disabled')
     else:
         ecosystem = aggregator._normalized_packages.ecosystem

--- a/src/v2/stack_aggregator.py
+++ b/src/v2/stack_aggregator.py
@@ -398,16 +398,15 @@ class Registered(Aggregator):
 
 def initiate_unknown_package_ingestion(aggregator: Aggregator):
     """Ingestion of Unknown dependencies."""
+    if Settings().disable_unknown_package_flow:
+        logger.warning('Skipping unknown flow %s', aggregator.get_all_unknown_packages())
+        return
+
     ecosystem = aggregator._normalized_packages.ecosystem
     try:
         for dep in aggregator.get_all_unknown_packages():
-            if Settings().disable_unknown_package_flow:
-                logger.warning('Unknown package {} with version {} skipped as '
-                               'DISABLE_UNKNOWN_PACKAGE_FLOW is set'.format(dep['name'],
-                                                                            dep['version']))
-            else:
-                server_create_analysis(ecosystem, dep.name, dep.version, api_flow=True,
-                                       force=False, force_graph_sync=True)
+            server_create_analysis(ecosystem, dep.name, dep.version, api_flow=True,
+                                   force=False, force_graph_sync=True)
     except Exception as e:  # pylint:disable=W0703,C0103
         logger.error('Ingestion failed for {%s, %s, %s}',
                      ecosystem, dep.name, dep.version)

--- a/src/v2/stack_aggregator.py
+++ b/src/v2/stack_aggregator.py
@@ -399,7 +399,10 @@ class Registered(Aggregator):
 
 def initiate_unknown_package_ingestion(aggregator: Aggregator):
     """Ingestion of Unknown dependencies."""
-    if os.environ.get("DISABLE_UNKNOWN_PACKAGE_FLOW", "") != "1":
+    if os.environ.get("DISABLE_UNKNOWN_PACKAGE_FLOW", "") == "1":
+        logger.warning('Unknown package flow is disabled')
+        print('Unknown package flow is disabled')
+    else:
         ecosystem = aggregator._normalized_packages.ecosystem
         try:
             for dep in aggregator.get_all_unknown_packages():

--- a/src/v2/stack_aggregator.py
+++ b/src/v2/stack_aggregator.py
@@ -398,18 +398,20 @@ class Registered(Aggregator):
 
 def initiate_unknown_package_ingestion(aggregator: Aggregator):
     """Ingestion of Unknown dependencies."""
-    if Settings().disable_unknown_package_flow:
-        logger.warning('Unknown package flow is disabled')
-    else:
-        ecosystem = aggregator._normalized_packages.ecosystem
-        try:
-            for dep in aggregator.get_all_unknown_packages():
+    ecosystem = aggregator._normalized_packages.ecosystem
+    try:
+        for dep in aggregator.get_all_unknown_packages():
+            if Settings().disable_unknown_package_flow:
+                logger.warning('Unknown package {} with version {} skipped as '
+                               'DISABLE_UNKNOWN_PACKAGE_FLOW is set'.format(dep['name'],
+                                                                            dep['version']))
+            else:
                 server_create_analysis(ecosystem, dep.name, dep.version, api_flow=True,
                                        force=False, force_graph_sync=True)
-        except Exception as e:  # pylint:disable=W0703,C0103
-            logger.error('Ingestion failed for {%s, %s, %s}',
-                         ecosystem, dep.name, dep.version)
-            logger.error(e)
+    except Exception as e:  # pylint:disable=W0703,C0103
+        logger.error('Ingestion failed for {%s, %s, %s}',
+                     ecosystem, dep.name, dep.version)
+        logger.error(e)
 
 
 class StackAggregator:

--- a/tests/test_stack_aggregator.py
+++ b/tests/test_stack_aggregator.py
@@ -79,17 +79,21 @@ def test_execute(_mock_get, _mock_post):
 @mock.patch('requests.get', side_effect=mock_dependency_response)
 @mock.patch('requests.Session.post', side_effect=mock_dependency_response)
 @mock.patch('stack_aggregator.server_create_analysis')
-def test_execute_with_disable_unkonwn_package_flow(_mock_get, _mock_post, _mock_unknown):
+def test_execute_unknonw_with_disable_unkonwn_package_flow(_mock_unknown, _mock_get,
+                                                           _mock_post, monkeypatch):
     """Test the function execute."""
     with open("tests/data/stack_aggregator_execute_input.json", "r") as f:
         payload = json.loads(f.read())
 
-    with mock.patch.dict('os.environ', {'DISABLE_UNKNOWN_PACKAGE_FLOW': '1'}):
-        s = stack_aggregator.StackAggregator()
-        out = s.execute(payload, False)
-        assert out['stack_aggregator'] == "success"
-        assert out['result']['stack_data'][0]['user_stack_info']['transitive_count'] == -1
-        _mock_unknown.assert_not_called()
+    # add unknown package as direct dependency
+    payload['result'][0]['details'][0]['_resolved'].append({'package': 'six', 'version': '3.2.1'})
+
+    monkeypatch.setenv('DISABLE_UNKNOWN_PACKAGE_FLOW', '1')
+    s = stack_aggregator.StackAggregator()
+    out = s.execute(payload, False)
+    assert out['stack_aggregator'] == "success"
+    assert out['result']['stack_data'][0]['user_stack_info']['transitive_count'] == -1
+    _mock_unknown.assert_not_called()
 
 
 def mock_licenses_resp_component_conflict(*_args, **_kwargs):

--- a/tests/test_stack_aggregator.py
+++ b/tests/test_stack_aggregator.py
@@ -76,6 +76,22 @@ def test_execute(_mock_get, _mock_post):
     assert out['result']['stack_data'][0]['user_stack_info']['transitive_count'] == -1
 
 
+@mock.patch('requests.get', side_effect=mock_dependency_response)
+@mock.patch('requests.Session.post', side_effect=mock_dependency_response)
+@mock.patch('stack_aggregator.server_create_analysis')
+def test_execute_with_disable_unkonwn_package_flow(_mock_get, _mock_post, _mock_unknown):
+    """Test the function execute."""
+    with open("tests/data/stack_aggregator_execute_input.json", "r") as f:
+        payload = json.loads(f.read())
+
+    with mock.patch.dict('os.environ', {'DISABLE_UNKNOWN_PACKAGE_FLOW': '1'}):
+        s = stack_aggregator.StackAggregator()
+        out = s.execute(payload, False)
+        assert out['stack_aggregator'] == "success"
+        assert out['result']['stack_data'][0]['user_stack_info']['transitive_count'] == -1
+        _mock_unknown.assert_not_called()
+
+
 def mock_licenses_resp_component_conflict(*_args, **_kwargs):
     """Mock the call to the insights service."""
     class MockResponse:

--- a/tests/v2/test_stack_aggregator.py
+++ b/tests/v2/test_stack_aggregator.py
@@ -174,7 +174,7 @@ def test_with_2_public_vuln_for_registered(_mock_license, _mock_gremlin):
 
 @mock.patch('src.v2.stack_aggregator.server_create_analysis')
 @mock.patch('src.v2.stack_aggregator.post_gremlin')
-def test_unknown_flow_with_disabled_flag(_mock_gremlin, _mock_unknown):
+def test_unknown_flow_with_disabled_flag(_mock_gremlin, _mock_unknown, monkeypatch):
     """Test unknown flow."""
     with open("tests/v2/data/graph_response_2_public_vuln.json", "r") as fin:
         _mock_gremlin.return_value = json.load(fin)
@@ -184,9 +184,9 @@ def test_unknown_flow_with_disabled_flag(_mock_gremlin, _mock_unknown):
     payload['packages'].append(_SIX.dict())
 
     # Disabled unknown flow check
-    with mock.patch.dict('os.environ', {'DISABLE_UNKNOWN_PACKAGE_FLOW': '1'}):
-        StackAggregator().execute(payload, persist=False)
-        _mock_unknown.assert_not_called()
+    monkeypatch.setenv('DISABLE_UNKNOWN_PACKAGE_FLOW', '1')
+    StackAggregator().execute(payload, persist=False)
+    _mock_unknown.assert_not_called()
 
 
 @mock.patch('src.v2.stack_aggregator.server_create_analysis')

--- a/tests/v2/test_stack_aggregator.py
+++ b/tests/v2/test_stack_aggregator.py
@@ -174,6 +174,23 @@ def test_with_2_public_vuln_for_registered(_mock_license, _mock_gremlin):
 
 @mock.patch('src.v2.stack_aggregator.server_create_analysis')
 @mock.patch('src.v2.stack_aggregator.post_gremlin')
+def test_unknown_flow_with_disabled_flag(_mock_gremlin, _mock_unknown):
+    """Test unknown flow."""
+    with open("tests/v2/data/graph_response_2_public_vuln.json", "r") as fin:
+        _mock_gremlin.return_value = json.load(fin)
+
+    payload = _request_body()
+    # add unknown package as direct dependency
+    payload['packages'].append(_SIX.dict())
+
+    # Disabled unknown flow check
+    with mock.patch.dict('os.environ', {'DISABLE_UNKNOWN_PACKAGE_FLOW': '1'}):
+        StackAggregator().execute(payload, persist=False)
+        _mock_unknown.assert_not_called()
+
+
+@mock.patch('src.v2.stack_aggregator.server_create_analysis')
+@mock.patch('src.v2.stack_aggregator.post_gremlin')
 @mock.patch('src.v2.stack_aggregator.get_license_analysis_for_stack')
 def test_unknown_flow(_mock_license, _mock_gremlin, _mock_unknown):
     """Test unknown flow."""


### PR DESCRIPTION
# Description

Need to add functionality to avoid triggering unknown dependencies flow for stack analyses in backbone server. This functionality should be controlled by an environment flag, so that it can be enabled for staging and disabled for production. This will be use-full in avoiding unknown dependencies flow for dummy dependencies ingested during e2e testing on staging.

Fixes # (issue)

https://issues.redhat.com/browse/APPAI-1294

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
