### PR TITLE
chore: Remove insights call to kronos

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       LICENSE_SERVICE_PORT: "6162"
       PGM_SERVICE_HOST: "bayesian-kronos"
       CHESTER_SERVICE_HOST: "f8a-chester"
-      PGM_SERVICE_PORT : "6006"
+      SERVICE_PORT : "6006"
       POSTGRESQL_USER: "user"
       POSTGRESQL_PASSWORD: "password"
       POSTGRESQL_DATABASE: "dbname"

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -50,8 +50,6 @@ objects:
             value: f8a-license-analysis
           - name: LICENSE_SERVICE_PORT
             value: "6162"
-          - name: PGM_SERVICE_HOST
-            value: bayesian-kronos
           - name: CHESTER_SERVICE_HOST
             value: f8a-npm-insights
           - name: PYPI_SERVICE_HOST
@@ -60,7 +58,7 @@ objects:
             value: f8a-golang-insights
           - name: HPF_SERVICE_HOST
             value: f8a-hpf-insights
-          - name: PGM_SERVICE_PORT
+          - name: SERVICE_PORT
             value: "6006"
           - name: POSTGRESQL_DATABASE
             valueFrom:

--- a/src/recommender.py
+++ b/src/recommender.py
@@ -73,8 +73,7 @@ import logging
 from src.utils import (create_package_dict, get_session_retry, select_latest_version,
                        GREMLIN_SERVER_URL_REST, LICENSE_SCORING_URL_REST,
                        convert_version_to_proper_semantic, get_response_data,
-                       version_info_tuple, persist_data_in_db,
-                       is_quickstart_majority, post_http_request)
+                       version_info_tuple, persist_data_in_db, post_http_request)
 from src.stack_aggregator import extract_user_stack_package_licenses
 
 logging.basicConfig(level=logging.INFO)
@@ -429,7 +428,6 @@ class RecommendationTask:
     def get_insights_url(payload):
         """Get the insights url based on the ecosystem."""
         if payload and 'ecosystem' in payload[0]:
-            quickstarts = False
             if payload[0]['ecosystem'] in RecommendationTask.chester_ecosystems:
                 INSIGHTS_SERVICE_HOST = os.getenv("CHESTER_SERVICE_HOST")
             elif payload[0]['ecosystem'] in RecommendationTask.pypi_ecosystems:
@@ -439,19 +437,11 @@ class RecommendationTask:
             else:
                 INSIGHTS_SERVICE_HOST = os.getenv("HPF_SERVICE_HOST") + "-" + payload[0][
                     'ecosystem']
-                if payload[0]['ecosystem'] == 'maven':
-                    quickstarts = is_quickstart_majority(payload[0]['package_list'])
-                if quickstarts:
-                    INSIGHTS_SERVICE_HOST = os.getenv("PGM_SERVICE_HOST") + "-" + payload[0][
-                        'ecosystem']
 
             INSIGHTS_URL_REST = "http://{host}:{port}".format(host=INSIGHTS_SERVICE_HOST,
-                                                              port=os.getenv("PGM_SERVICE_PORT"))
+                                                              port=os.getenv("SERVICE_PORT"))
 
-            if quickstarts:
-                insights_url = INSIGHTS_URL_REST + "/api/v1/schemas/kronos_scoring"
-            else:
-                insights_url = INSIGHTS_URL_REST + "/api/v1/companion_recommendation"
+            insights_url = INSIGHTS_URL_REST + "/api/v1/companion_recommendation"
 
             return insights_url
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -49,9 +49,6 @@ LICENSE_SCORING_URL_REST = "http://{host}:{port}".format(
 
 zero_version = sv.Version("0.0.0")
 # Create Postgres Connection Session
-quickstart_tuple = ("org.wildfly.swarm",
-                    "org.springframework.boot",
-                    "io.vertx")
 fmt = "%Y-%m-%dT%H:%M:%S.%f"
 worker_count = int(os.getenv('FUTURES_SESSION_WORKER_COUNT', '100'))
 _session = FuturesSession(max_workers=worker_count)
@@ -291,20 +288,6 @@ def get_session_retry(retries=3, backoff_factor=0.2, status_forcelist=(404, 500,
     adapter = HTTPAdapter(max_retries=retry)
     session.mount('http://', adapter)
     return session
-
-
-def is_quickstart_majority(package_list=[]):
-    """Return true if 50% or more packages are from quickstarts.
-
-    param package_list: The list of packages in the payload.
-    """
-    count_quickstart_pck = 0
-    for package_name in package_list:
-        if package_name.startswith(quickstart_tuple):
-            count_quickstart_pck += 1
-    # If 50% or more packages reflect quickstarts, pick kronos.
-    # Defaults to Kronos if package_list is empty
-    return count_quickstart_pck >= len(package_list) / 2
 
 
 def persist_data_in_db(external_request_id, task_result, worker, started_at=None, ended_at=None):

--- a/src/v2/recommender.py
+++ b/src/v2/recommender.py
@@ -15,7 +15,7 @@ from collections import defaultdict
 from src.utils import (create_package_dict, get_session_retry, select_latest_version,
                        LICENSE_SCORING_URL_REST, convert_version_to_proper_semantic,
                        get_response_data, version_info_tuple, persist_data_in_db,
-                       is_quickstart_majority, post_gremlin)
+                       post_gremlin)
 from src.v2.models import RecommenderRequest, StackRecommendationResult
 from src.v2.stack_aggregator import extract_user_stack_package_licenses
 from src.v2.normalized_packages import NormalizedPackages
@@ -293,7 +293,6 @@ class RecommendationTask:
     def get_insights_url(payload):
         """Get the insights url based on the ecosystem."""
         if payload and 'ecosystem' in payload[0]:
-            quickstarts = False
             if payload[0]['ecosystem'] in RecommendationTask.chester_ecosystems:
                 INSIGHTS_SERVICE_HOST = os.getenv("CHESTER_SERVICE_HOST")
             elif payload[0]['ecosystem'] in RecommendationTask.pypi_ecosystems:
@@ -303,19 +302,11 @@ class RecommendationTask:
             else:
                 INSIGHTS_SERVICE_HOST = os.getenv("HPF_SERVICE_HOST") + "-" + payload[0][
                     'ecosystem']
-                if payload[0]['ecosystem'] == 'maven':
-                    quickstarts = is_quickstart_majority(payload[0]['package_list'])
-                if quickstarts:
-                    INSIGHTS_SERVICE_HOST = os.getenv("PGM_SERVICE_HOST") + "-" + payload[0][
-                        'ecosystem']
 
             INSIGHTS_URL_REST = "http://{host}:{port}".format(host=INSIGHTS_SERVICE_HOST,
-                                                              port=os.getenv("PGM_SERVICE_PORT"))
+                                                              port=os.getenv("SERVICE_PORT"))
 
-            if quickstarts:
-                insights_url = INSIGHTS_URL_REST + "/api/v1/schemas/kronos_scoring"
-            else:
-                insights_url = INSIGHTS_URL_REST + "/api/v1/companion_recommendation"
+            insights_url = INSIGHTS_URL_REST + "/api/v1/companion_recommendation"
 
             return insights_url
 

--- a/tests/test_recommender.py
+++ b/tests/test_recommender.py
@@ -55,7 +55,7 @@ class TestRecommendationTask(TestCase):
                 'CHESTER_SERVICE_HOST': 'npm-insights',
                 'PYPI_SERVICE_HOST': 'pypi-insights',
                 'PGM_SERVICE_HOST': 'pgm',
-                'PGM_SERVICE_PORT': '6006',
+                'SERVICE_PORT': '6006',
                 'HPF_SERVICE_HOST': 'hpf-insights',
              }):
             # Test whether the correct service is called for NPM.
@@ -72,10 +72,6 @@ class TestRecommendationTask(TestCase):
             }])
             self.assertTrue('golang-insights' in called_url_json['url'])
             # Now test whether the correct service is called for maven.
-            called_url_json = RecommendationTask.call_insights_recommender(
-                [{"ecosystem": "maven", "package_list": []}])
-            self.assertTrue('pgm' in called_url_json['url'])
-
             called_url_json = RecommendationTask.call_insights_recommender(
                 [{"ecosystem": "maven", "package_list": ["org.slf4j:slf4j-api"]}])
             self.assertTrue('hpf-insights' in called_url_json['url'])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@ from src.utils import push_data, get_time_delta
 from src.utils import (
     convert_version_to_proper_semantic as cvs, GREMLIN_SERVER_URL_REST, format_date,
     version_info_tuple as vt, select_latest_version as slv,
-    get_osio_user_count, create_package_dict, is_quickstart_majority, post_http_request,
+    get_osio_user_count, create_package_dict, post_http_request,
     server_create_analysis, select_from_db, total_time_elapsed, post_gremlin,
     GremlinExeception, RequestException)
 
@@ -163,18 +163,6 @@ def test_create_package_dict(_mock_count):
     assert len(out) > 1
 
 
-def test_is_quickstart_majority():
-    """Test the function is_quickstart_majority."""
-    package_list = []
-    assert is_quickstart_majority(package_list)
-    package_list = ['io.vertx:vertx-core',
-                    'org.springframework.boot:spring-boot-starter-web',
-                    'org.slf4j:slf4j-api']
-    assert is_quickstart_majority(package_list)
-    package_list = ['org.slf4j:slf4j-api']
-    assert not is_quickstart_majority(package_list)
-
-
 @mock.patch('requests.Session.post', side_effect=mock_error_response)
 def test_post_http_request(_mock1):
     """Test error response for gremlin."""
@@ -262,7 +250,6 @@ if __name__ == '__main__':
     test_version_info_tuple()
     test_select_latest_version()
     test_get_osio_user_count()
-    test_is_quickstart_majority()
     test_post_http_request()
     test_create_package_dict()
     test_server_create_analysis()

--- a/tests/v2/test_recommender.py
+++ b/tests/v2/test_recommender.py
@@ -55,7 +55,7 @@ class TestRecommendationTask(TestCase):
                 'CHESTER_SERVICE_HOST': 'npm-insights',
                 'PYPI_SERVICE_HOST': 'pypi-insights',
                 'PGM_SERVICE_HOST': 'pgm',
-                'PGM_SERVICE_PORT': '6006',
+                'SERVICE_PORT': '6006',
                 'HPF_SERVICE_HOST': 'hpf-insights',
              }):
             # Test whether the correct service is called for NPM.
@@ -71,11 +71,7 @@ class TestRecommendationTask(TestCase):
                 "ecosystem": "golang"
             }])
             self.assertTrue('golang-insights' in called_url_json['url'])
-            # Now test whether the correct service is called for maven.
-            called_url_json = RecommendationTask.call_insights_recommender(
-                [{"ecosystem": "maven", "package_list": []}])
-            self.assertTrue('pgm' in called_url_json['url'])
-
+            # # Now test whether the correct service is called for maven.
             called_url_json = RecommendationTask.call_insights_recommender(
                 [{"ecosystem": "maven", "package_list": ["org.slf4j:slf4j-api"]}])
             self.assertTrue('hpf-insights' in called_url_json['url'])


### PR DESCRIPTION
removing the call to the kronos insight service as it is not longer required. all maven packages are now handled by hpf.



