### PR TITLE
fix: URLEncode the package component

### DIFF
--- a/src/v2/stack_aggregator.py
+++ b/src/v2/stack_aggregator.py
@@ -9,6 +9,7 @@ import inspect
 import time
 import logging
 from collections import defaultdict
+from urllib.parse import quote
 
 from typing import Dict, List, Tuple, Set
 from f8a_utils.gh_utils import GithubUtils
@@ -130,10 +131,10 @@ def _has_vulnerability(pkg: PackageDetails) -> bool:
 
 
 # (fixme) link to snyk package should be identified during ingestion.
-def _get_snyk_package_link(ecosystem, package):
+def _get_snyk_package_link(ecosystem: str, package: str) -> str:
     ecosystem = Settings().snyk_ecosystem_map.get(ecosystem, ecosystem)
     return Settings().snyk_package_url_format.format(ecosystem=ecosystem,
-                                                     package=package)
+                                                     package=quote(package, safe=''))
 
 
 class Aggregator:

--- a/tests/v2/test_stack_aggregator.py
+++ b/tests/v2/test_stack_aggregator.py
@@ -382,7 +382,6 @@ class TestStackAggregator(TestCase):
         self.assertEqual(len(resp['result']['analyzed_dependencies'][0]
                              ['public_vulnerabilities']), 3)
 
-        print(resp['result']['analyzed_dependencies'][0]['url'])
         self.assertEqual(resp['result']['analyzed_dependencies'][0]['url'],
                          'https://snyk.io/vuln/golang:github.com%2Fgophish%2Fgophish%2Fcontrollers')
         self.assertEqual(resp['result']['analyzed_dependencies'][0]

--- a/tests/v2/test_stack_aggregator.py
+++ b/tests/v2/test_stack_aggregator.py
@@ -382,6 +382,9 @@ class TestStackAggregator(TestCase):
         self.assertEqual(len(resp['result']['analyzed_dependencies'][0]
                              ['public_vulnerabilities']), 3)
 
+        print(resp['result']['analyzed_dependencies'][0]['url'])
+        self.assertEqual(resp['result']['analyzed_dependencies'][0]['url'],
+                         'https://snyk.io/vuln/golang:github.com%2Fgophish%2Fgophish%2Fcontrollers')
         self.assertEqual(resp['result']['analyzed_dependencies'][0]
                          ['public_vulnerabilities'][0]['cve_ids'], ['CVE-2020-24711'])
         self.assertEqual(resp['result']['analyzed_dependencies'][0]


### PR DESCRIPTION
# Description

golang package name is a full qualified URI, it should be URLEncoded because it is passed as query param to `https://snyk.io/vuln/{ecosystem}:{package}` .

Fixes https://issues.redhat.com/browse/APPAI-1637

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
