### PR TITLE
feat: Enable gevent based concurrent gunicorn worker

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -81,10 +81,12 @@ objects:
             value: "5000"
           - name: WORKER_TIMEOUT
             value: ${WORKER_TIMEOUT}
+          - name: WORKER_CONNECTIONS
+            value: "1024"
+          - name: WORKER_CLASS
+            value: "gevent"
           - name: WORKERS_COUNT
             value: "4"
-          - name: WORKERS_CLASS
-            value: "sync"
           - name: FLASK_LOGGING_LEVEL
             value: ${FLASK_LOGGING_LEVEL}
           - name: METRICS_ENDPOINT_URL

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -79,11 +79,11 @@ objects:
                 key: aws_secret_access_key
           - name: API_BACKBONE_SERVICE_PORT
             value: "5000"
-          - name: API_BACKBONE_SERVICE_TIMEOUT
-            value: ${API_BACKBONE_SERVICE_TIMEOUT}
-          - name: NUMBER_WORKER_PROCESS
+          - name: WORKER_TIMEOUT
+            value: ${WORKER_TIMEOUT}
+          - name: WORKERS_COUNT
             value: "4"
-          - name: CLASS_TYPE
+          - name: WORKERS_CLASS
             value: "sync"
           - name: FLASK_LOGGING_LEVEL
             value: ${FLASK_LOGGING_LEVEL}
@@ -210,11 +210,11 @@ parameters:
   name: API_BACKBONE_SERVICE_PORT
   value: "5000"
 
-- description: API Service Timeout
-  displayName: API Service Timeout
+- description: Worker Timeout
+  displayName: Worker Timeout
   required: true
-  name: API_BACKBONE_SERVICE_TIMEOUT
-  value: "300"
+  name: WORKER_TIMEOUT
+  value: "120"
 
 - description: "Flask logging level (see: https://docs.python.org/3/library/logging.html#levels)"
   displayName: Flask logging level

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/bash
 
 # Start API backbone service with time out
-gunicorn --pythonpath /src/ -b 0.0.0.0:$API_BACKBONE_SERVICE_PORT -t $API_BACKBONE_SERVICE_TIMEOUT -k $CLASS_TYPE -w $NUMBER_WORKER_PROCESS rest_api:app --reload --log-level $FLASK_LOGGING_LEVEL
+gunicorn --pythonpath /src/ -b 0.0.0.0:$API_BACKBONE_SERVICE_PORT -c /src/conf/gunicorn_backbone.py rest_api:app --log-level $FLASK_LOGGING_LEVEL

--- a/src/conf/gunicorn_backbone.py
+++ b/src/conf/gunicorn_backbone.py
@@ -7,7 +7,7 @@ workers = GUNICORN_SETTINGS.workers
 worker_class = GUNICORN_SETTINGS.worker_class
 timeout = GUNICORN_SETTINGS.timeout
 preload_app = GUNICORN_SETTINGS.preload
-reload = preload_app is True
+reload = preload_app is not True
 
 
 def when_ready(server):  # noqa

--- a/src/conf/gunicorn_backbone.py
+++ b/src/conf/gunicorn_backbone.py
@@ -1,0 +1,16 @@
+import logging
+from src.settings import GUNICORN_SETTINGS
+
+workers = GUNICORN_SETTINGS.workers
+worker_class = GUNICORN_SETTINGS.worker_class
+timeout = GUNICORN_SETTINGS.timeout
+
+preload_app = True
+reload = True
+
+
+def when_ready(server):
+    logger = logging.getLogger(__name__)
+    logger.debug(
+        "Starting backbone gunicorn with %s workers and %s worker class", workers, worker_class
+    )

--- a/src/conf/gunicorn_backbone.py
+++ b/src/conf/gunicorn_backbone.py
@@ -1,16 +1,21 @@
+"""Gunicorn config."""
+
 import logging
 from src.settings import GUNICORN_SETTINGS
 
 workers = GUNICORN_SETTINGS.workers
 worker_class = GUNICORN_SETTINGS.worker_class
 timeout = GUNICORN_SETTINGS.timeout
+preload_app = GUNICORN_SETTINGS.preload
+reload = preload_app != True
 
-preload_app = True
-reload = True
 
-
-def when_ready(server):
+def when_ready(server):  # noqa
+    """Log when worker is ready to serve."""
     logger = logging.getLogger(__name__)
-    logger.debug(
-        "Starting backbone gunicorn with %s workers and %s worker class", workers, worker_class
+    logger.info(
+        "Starting backbone gunicorn with %s workers %s worker class and preload %s",
+        workers,
+        worker_class,
+        preload_app,
     )

--- a/src/conf/gunicorn_backbone.py
+++ b/src/conf/gunicorn_backbone.py
@@ -1,4 +1,8 @@
 """Gunicorn config."""
+# NOTE: Must be before we import or call anything that may be synchronous.
+from gevent import monkey
+
+monkey.patch_all()
 
 import logging
 from src.settings import GUNICORN_SETTINGS
@@ -7,6 +11,7 @@ workers = GUNICORN_SETTINGS.workers
 worker_class = GUNICORN_SETTINGS.worker_class
 timeout = GUNICORN_SETTINGS.timeout
 preload_app = GUNICORN_SETTINGS.preload
+worker_connections = GUNICORN_SETTINGS.worker_connections
 reload = preload_app is not True
 
 

--- a/src/conf/gunicorn_backbone.py
+++ b/src/conf/gunicorn_backbone.py
@@ -7,7 +7,7 @@ workers = GUNICORN_SETTINGS.workers
 worker_class = GUNICORN_SETTINGS.worker_class
 timeout = GUNICORN_SETTINGS.timeout
 preload_app = GUNICORN_SETTINGS.preload
-reload = preload_app != True
+reload = preload_app is True
 
 
 def when_ready(server):  # noqa

--- a/src/settings.py
+++ b/src/settings.py
@@ -31,11 +31,12 @@ class Settings(BaseSettings):
 
 
 class GunicornSettings(BaseSettings):
-    """Gunicorn settings"""
+    """Gunicorn settings."""
 
     workers: int = Field(default=2, env="WORKERS_COUNT")
-    worker_class: str = Field(default="sync", env="WORKERS_CLASS")
+    worker_class: str = Field(default="sync", env="WORKER_CLASS")
     timeout: int = Field(default=120, env="WORKER_TIMEOUT")
+    preload: bool = Field(default=True, env="WORKER_PRELOAD")
 
 
 SETTINGS = Settings()

--- a/src/settings.py
+++ b/src/settings.py
@@ -34,7 +34,7 @@ class GunicornSettings(BaseSettings):
     """Gunicorn settings."""
 
     workers: int = Field(default=2, env="WORKER_COUNT")
-    worker_class: str = Field(default="sync", env="WORKER_CLASS")
+    worker_class: str = Field(default="gevent", env="WORKER_CLASS")
     timeout: int = Field(default=120, env="WORKER_TIMEOUT")
     preload: bool = Field(default=True, env="WORKER_PRELOAD")
     worker_connections: int = Field(default=1024, env="WORKER_CONNECTIONS")

--- a/src/settings.py
+++ b/src/settings.py
@@ -2,7 +2,7 @@
 
 
 from typing import Dict
-from pydantic import BaseSettings, HttpUrl, AnyHttpUrl
+from pydantic import BaseSettings, HttpUrl, AnyHttpUrl, Field
 
 
 class AggregatorSettings(BaseSettings):
@@ -30,6 +30,15 @@ class Settings(BaseSettings):
     gremlin_url: AnyHttpUrl = "http://bayesian-gremlin-http:8182"
 
 
+class GunicornSettings(BaseSettings):
+    """Gunicorn settings"""
+
+    workers: int = Field(default=2, env="WORKERS_COUNT")
+    worker_class: str = Field(default="sync", env="WORKERS_CLASS")
+    timeout: int = Field(default=120, env="WORKER_TIMEOUT")
+
+
 SETTINGS = Settings()
 RECOMMENDER_SETTINGS = RecommenderSettings()
 AGGREGATOR_SETTINGS = AggregatorSettings()
+GUNICORN_SETTINGS = GunicornSettings()

--- a/src/settings.py
+++ b/src/settings.py
@@ -33,7 +33,7 @@ class Settings(BaseSettings):
 class GunicornSettings(BaseSettings):
     """Gunicorn settings."""
 
-    workers: int = Field(default=2, env="WORKERS_COUNT")
+    workers: int = Field(default=2, env="WORKER_COUNT")
     worker_class: str = Field(default="sync", env="WORKER_CLASS")
     timeout: int = Field(default=120, env="WORKER_TIMEOUT")
     preload: bool = Field(default=True, env="WORKER_PRELOAD")

--- a/src/settings.py
+++ b/src/settings.py
@@ -34,9 +34,10 @@ class GunicornSettings(BaseSettings):
     """Gunicorn settings."""
 
     workers: int = Field(default=2, env="WORKERS_COUNT")
-    worker_class: str = Field(default="sync", env="WORKER_CLASS")
+    worker_class: str = Field(default="gevent", env="WORKER_CLASS")
     timeout: int = Field(default=120, env="WORKER_TIMEOUT")
     preload: bool = Field(default=True, env="WORKER_PRELOAD")
+    worker_connections: int = Field(default=1024, env="WORKER_CONNECTIONS")
 
 
 SETTINGS = Settings()


### PR DESCRIPTION
Spans out new co routes on each i/o blocking call. Co-routes will be executed once the blocking i/o completes.

Inspired from: https://github.com/quay/quay/blob/master/conf/gunicorn_secscan.py