### PR TITLE
chore: split build to 2 scripts

### DIFF
--- a/build_deploy.rhel.sh
+++ b/build_deploy.rhel.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
 set -exv
 
-BASE_IMG="fabric8-analytics-f8a-server-backbone"
+BASE_IMG="rhel-fabric8-analytics-f8a-server-backbone"
 QUAY_IMAGE="quay.io/app-sre/${BASE_IMG}"
 IMG="${BASE_IMG}:latest"
 
 GIT_HASH=`git rev-parse --short=7 HEAD`
+
+# login to quay to pull base image
+DOCKER_CONF="$PWD/.docker"
+mkdir -p "$DOCKER_CONF"
+docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
 # build the image
 docker build  --no-cache \

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -11,7 +11,7 @@ GIT_HASH=`git rev-parse --short=7 HEAD`
 docker build  --no-cache \
               --force-rm \
               -t ${IMG}  \
-              -f ./Dockerfile.app-sre.rhel .
+              -f ./Dockerfile .
 
 # push the image
 skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \


### PR DESCRIPTION
This PR adds an additional build_deploy script. now we will have one build_deploy to build the rhel image and one to build the standard image.

this is required because we want to run these jobs on separate nodes.

this is required for https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/15202