### PR TITLE
fix: alter copy instructions according to ubi default working dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@ ENV LANG=en_US.UTF-8 PYTHONDONTWRITEBYTECODE=1
 
 RUN pip3 install --upgrade --no-cache-dir pip
 
-COPY ./requirements.txt /
-RUN pip3 install --no-cache-dir -r /requirements.txt
+COPY ./requirements.txt /opt/app-root
+RUN pip3 install --no-cache-dir -r /opt/app-root/requirements.txt
 
-COPY ./src /src
+COPY ./src /opt/app-root/src/src
 ADD scripts/entrypoint.sh /bin/entrypoint.sh
 
 ENTRYPOINT ["bash", "/bin/entrypoint.sh"]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/bash
 
 # Start API backbone service with time out
-gunicorn --pythonpath /src/ -b 0.0.0.0:$API_BACKBONE_SERVICE_PORT -c /src/conf/gunicorn_backbone.py rest_api:app --log-level $FLASK_LOGGING_LEVEL
+gunicorn -b 0.0.0.0:$API_BACKBONE_SERVICE_PORT -c src/conf/gunicorn_backbone.py src.rest_api:app --log-level $FLASK_LOGGING_LEVEL


### PR DESCRIPTION
`ubi8/python36` working dir defaults to `/opt/app-root`. Alter the copy instructions accordingly.